### PR TITLE
docs: add feature info, show 'available on feature ...' badge

### DIFF
--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![allow(unsafe_code)]
 // FFI wrapper crate: i32 ↔ usize casts at the C boundary are systematic and


### PR DESCRIPTION
# Description

This PR fill add a feature badge to the docs. This code example below should be marked with this badge, since `AlloySigner` is only available on feature `alloy`.

## Changes

added `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` in lib.rs of xmtp lib crate.


## Relevant Code Example
```rust,ignore
use xmtp::{Client, Env, AlloySigner};

// Create a client and register identity.
let signer = AlloySigner::random()?;
let client = Client::builder()
    .env(Env::Dev)
    .db_path("./alice.db3")
    .build(&signer)?;

// Send a DM.
let conv = client.dm(&"0xBob...".into())?;
conv.send_text("hello from Rust")?;

// Stream messages in real time.
let _handle = xmtp::stream::stream_all_messages(
    &client, None, &[], |msg_id, conv_id| {
        println!("new message {msg_id} in {conv_id}");
    },
)?;
```
