### PR TITLE
fix(ci): Dependabot sweep on schedule only

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,12 +1,9 @@
 # Caller owns on:. Pin at @v2.
-# pull_request: try to queue GitHub auto-merge (no-op without required checks).
 # schedule: squash-merge Dependabot PRs whose checks are green.
-# Do not checkout the PR. This workflow does not approve.
-# If rulesets require reviews, add a bypass for Dependabot or pass TOKEN.
+# workflow_dispatch: same sweep. Do not checkout the PR. Does not approve.
 name: Dependabot
 
 on:
-  pull_request:
   schedule:
     - cron: '*/15 * * * *'
   workflow_dispatch:
@@ -17,9 +14,6 @@ permissions:
 
 jobs:
   merge:
-    if: >-
-      github.event_name != 'pull_request'
-      || github.event.pull_request.user.login == 'dependabot[bot]'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Drop `pull_request`. Caller `on:` is `schedule` (`*/15`) + `workflow_dispatch` only. Pin remains `@v2`.

The sweep squash-merges Dependabot PRs whose checks are green. Do not checkout the PR. Does not approve.
